### PR TITLE
Allow passing fewer than 35 or 25 enrollment test answers

### DIFF
--- a/api/models/enrollment_tests.py
+++ b/api/models/enrollment_tests.py
@@ -79,7 +79,7 @@ class EnrollmentTestResult(models.Model):
         return (
             f"Answers to enrollment test by {self.student} "
             f"({self.correct_answers_count} correct "
-            f"out of {self.answers.count()})"
+            f"out of {self.answers.count()} answers given)"
         )
 
     @property

--- a/api/serializers/enrollment_test.py
+++ b/api/serializers/enrollment_test.py
@@ -62,17 +62,18 @@ class EnrollmentTestResultLevelSerializer(serializers.ModelSerializer[Enrollment
     """A serializer used to get level of language based on how many answers are correct."""
 
     resulting_level = serializers.SerializerMethodField()
+    number_of_questions = serializers.IntegerField(min_value=1, max_value=50, write_only=True)
 
     class Meta:
         model = EnrollmentTestResult
-        fields = ("answers", "resulting_level")
+        fields = ("answers", "number_of_questions", "resulting_level")
         extra_kwargs = {"answers": {"write_only": True}}
 
     def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
-        number_of_answers = len(attrs["answers"])
-        if number_of_answers not in ENROLLMENT_TEST_LEVEL_THRESHOLDS_FOR_NUMBER_OF_QUESTIONS:
+        number_of_questions = attrs["number_of_questions"]
+        if number_of_questions not in ENROLLMENT_TEST_LEVEL_THRESHOLDS_FOR_NUMBER_OF_QUESTIONS:
             raise serializers.ValidationError(
-                f"Enrollment test with {number_of_answers} questions is not supported"
+                f"Enrollment test with {number_of_questions} questions is not supported"
             )
         return attrs
 
@@ -81,7 +82,7 @@ class EnrollmentTestResultLevelSerializer(serializers.ModelSerializer[Enrollment
         # level thresholds (= numbers of correct answers required to reach that level)
         # depend on total number of questions
         level_for_threshold = ENROLLMENT_TEST_LEVEL_THRESHOLDS_FOR_NUMBER_OF_QUESTIONS[
-            len(obj["answers"])
+            obj["number_of_questions"]
         ]
 
         number_of_correct_answers = len([answer for answer in obj["answers"] if answer.is_correct])

--- a/api/views/enrollment_test.py
+++ b/api/views/enrollment_test.py
@@ -29,7 +29,12 @@ class EnrollmentTestResultViewSet(CreateModelMixin, GenericViewSet[EnrollmentTes
 
     @action(detail=False, methods=["post"])
     def get_level(self, request: Request) -> Response:
-        """Calculates level of language based on number of correct answers."""
+        """Calculates level of language based on number of correct answers and number of questions.
+
+        The number of questions is passed explicitly to allow incomplete list of answers
+        (which will be the case if user aborts the test) and avoid inferring the number of
+        questions from the number of answers.
+        """
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         return Response(serializer.data)

--- a/tests/tests_api/test_enrollment_test.py
+++ b/tests/tests_api/test_enrollment_test.py
@@ -77,7 +77,7 @@ def test_get_enrollment_test(api_client):
         (25, 5, 0, "A0"),
     ],
 )
-def test_get_level_with_not_all_answers(
+def test_get_level(
     api_client, number_of_questions, total_answers, correct_answers, expected_level
 ):
     """Test calculating the resulting level of enrollment test."""

--- a/tests/tests_api/test_enrollment_test.py
+++ b/tests/tests_api/test_enrollment_test.py
@@ -34,31 +34,52 @@ def test_get_enrollment_test(api_client):
 
 
 @pytest.mark.parametrize(
-    "total_answers, correct_answers, expected_level",
+    "number_of_questions, total_answers, correct_answers, expected_level",
     [
-        (35, 35, "C1"),
-        (35, 32, "C1"),
-        (35, 31, "B2"),
-        (35, 27, "B2"),
-        (35, 26, "B1"),
-        (35, 20, "B1"),
-        (35, 19, "A2"),
-        (35, 13, "A2"),
-        (35, 12, "A1"),
-        (35, 6, "A1"),
-        (35, 5, "A0"),
-        (35, 0, "A0"),
-        (25, 25, "B1"),
-        (25, 19, "B1"),
-        (25, 18, "A2"),
-        (25, 11, "A2"),
-        (25, 10, "A1"),
-        (25, 5, "A1"),
-        (25, 4, "A0"),
-        (25, 0, "A0"),
+        (35, 35, 35, "C1"),
+        (35, 35, 32, "C1"),
+        (35, 35, 31, "B2"),
+        (35, 35, 27, "B2"),
+        (35, 35, 26, "B1"),
+        (35, 35, 20, "B1"),
+        (35, 35, 19, "A2"),
+        (35, 35, 13, "A2"),
+        (35, 35, 12, "A1"),
+        (35, 35, 6, "A1"),
+        (35, 35, 5, "A0"),
+        (35, 35, 0, "A0"),
+        (25, 25, 25, "B1"),
+        (25, 25, 19, "B1"),
+        (25, 25, 18, "A2"),
+        (25, 25, 11, "A2"),
+        (25, 25, 10, "A1"),
+        (25, 25, 5, "A1"),
+        (25, 25, 4, "A0"),
+        (25, 25, 0, "A0"),
+        # Imitating the user cancelling the test prematurely - fewer answers than questions:
+        (35, 33, 32, "C1"),
+        (35, 32, 31, "B2"),
+        (35, 28, 27, "B2"),
+        (35, 27, 26, "B1"),
+        (35, 21, 20, "B1"),
+        (35, 20, 19, "A2"),
+        (35, 14, 13, "A2"),
+        (35, 13, 12, "A1"),
+        (35, 7, 6, "A1"),
+        (35, 6, 5, "A0"),
+        (35, 5, 0, "A0"),
+        (25, 20, 19, "B1"),
+        (25, 19, 18, "A2"),
+        (25, 12, 11, "A2"),
+        (25, 11, 10, "A1"),
+        (25, 6, 5, "A1"),
+        (25, 5, 4, "A0"),
+        (25, 5, 0, "A0"),
     ],
 )
-def test_get_level(api_client, total_answers, correct_answers, expected_level):
+def test_get_level_with_not_all_answers(
+    api_client, number_of_questions, total_answers, correct_answers, expected_level
+):
     """Test calculating the resulting level of enrollment test."""
     # Don't need to specify a test here, just take some correct and incorrect answers to any test
     correct_answers_ids = list(
@@ -71,7 +92,10 @@ def test_get_level(api_client, total_answers, correct_answers, expected_level):
 
     response = api_client.post(
         "/api/enrollment_test_result/get_level/",
-        data={"answers": correct_answers_ids + incorrect_answers_ids},
+        data={
+            "answers": correct_answers_ids + incorrect_answers_ids,
+            "number_of_questions": number_of_questions,
+        },
     )
     assert response.status_code == status.HTTP_200_OK
     assert response.json() == {
@@ -79,16 +103,16 @@ def test_get_level(api_client, total_answers, correct_answers, expected_level):
     }
 
 
-def test_get_level_raises_400_with_wrong_number_of_answers(api_client):
+def test_get_level_raises_400_with_wrong_number_of_questions(api_client):
     test = baker.make_recipe("tests.enrollment_test")
     correct_answers_ids = list(
         EnrollmentTestQuestionOption.objects.filter(
             question__enrollment_test=test, is_correct=True
         ).values_list("id", flat=True)
-    )[:-1]
+    )
     response = api_client.post(
         "/api/enrollment_test_result/get_level/",
-        data={"answers": correct_answers_ids},
+        data={"answers": correct_answers_ids, "number_of_questions": len(correct_answers_ids) - 1},
     )
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert response.json() == {


### PR DESCRIPTION
In #88 (that closes #89) we determine a level based on number of the correct answers. The total number of *questions* is **inferred** from the total number of *answers*. However, this is not optimal as the user should be allowed to stop the assessment prematurely (which would be an equivalent of replying "I don't know" to all the remaining questions) and still get the level calculated correctly, since the level depends not only on the number of correct answers, but also on total number of questions.

Hence, the client can pass to the backend another item in `data`: number of questions. This should be very easy because the client just has to count the questions as it receives them from the backend, and store this number. Then the client passes this number back to the backend along with the answers, thus allowing the backend to calculate the level correctly without additional DB hits required to get to the `EnrollmentTest` and count its questions.

Optionally, if client doesn't allow the user to interrupt the test, it can just send the number of answers as number of questions.