### PR TITLE
Add ID to `languages_and_levels` fields for dashboard `teachers` and `students` views

### DIFF
--- a/api/serializers/language_and_level.py
+++ b/api/serializers/language_and_level.py
@@ -25,4 +25,4 @@ class MinifiedLanguageAndLevelSerializer(serializers.ModelSerializer[LanguageAnd
 
     class Meta:
         model = LanguageAndLevel
-        fields = ("language", "level")
+        fields = ("id", "language", "level")

--- a/tests/tests_api/test_group.py
+++ b/tests/tests_api/test_group.py
@@ -47,6 +47,7 @@ def test_dashboard_group_list(api_client, availability_slots):
             "saturday": str(group.saturday),
             "sunday": str(group.sunday),
             "language_and_level": {
+                "id": group.language_and_level.pk,
                 "language": group.language_and_level.language.name,
                 "level": group.language_and_level.level.id,
             },
@@ -97,6 +98,7 @@ def test_dashboard_group_retrieve(api_client, availability_slots):
         "saturday": str(group.saturday),
         "sunday": str(group.sunday),
         "language_and_level": {
+            "id": group.language_and_level.pk,
             "language": group.language_and_level.language.name,
             "level": group.language_and_level.level.id,
         },

--- a/tests/tests_api/test_student.py
+++ b/tests/tests_api/test_student.py
@@ -127,6 +127,7 @@ def test_dashboard_student_retrieve(api_client, faker, availability_slots):
     assert response.status_code == status.HTTP_200_OK
     languages_and_levels = [
         {
+            "id": language_and_level.pk,
             "language": language_and_level.language.name,
             "level": language_and_level.level.id,
         }


### PR DESCRIPTION
fixes #193 