### PR TITLE
Add email field to personal info filter to identify coordinator from dashboard

### DIFF
--- a/api/filters/personal_info.py
+++ b/api/filters/personal_info.py
@@ -6,4 +6,10 @@ from api.models import PersonalInfo
 class PersonalInfoFilter(filters.FilterSet):
     class Meta:
         model = PersonalInfo
-        fields = ("registration_telegram_bot_chat_id", "email")
+        fields = ("registration_telegram_bot_chat_id",)
+
+
+class DashboardPersonalInfoFilter(filters.FilterSet):
+    class Meta:
+        model = PersonalInfo
+        fields = ("email",)

--- a/api/filters/personal_info.py
+++ b/api/filters/personal_info.py
@@ -6,4 +6,4 @@ from api.models import PersonalInfo
 class PersonalInfoFilter(filters.FilterSet):
     class Meta:
         model = PersonalInfo
-        fields = ("registration_telegram_bot_chat_id",)
+        fields = ("registration_telegram_bot_chat_id", "email")

--- a/api/serializers/personal_info.py
+++ b/api/serializers/personal_info.py
@@ -54,7 +54,11 @@ class CheckChatIdExistenceSerializer(serializers.ModelSerializer[PersonalInfo]):
 
 
 class DashboardPersonalInfoSerializer(serializers.ModelSerializer[PersonalInfo]):
-    """A serializer used to return information about a person in dashboard (Tooljet) views."""
+    """
+    A serializer used to return information about a person in dashboard (Tooljet) views.
+    The data returned is nested inside a parent entity (teacher or student),
+    so fields like id and name are not returned here.
+    """
 
     class Meta:
         model = PersonalInfo
@@ -65,3 +69,18 @@ class DashboardPersonalInfoSerializer(serializers.ModelSerializer[PersonalInfo])
             "registration_telegram_bot_chat_id",
             "telegram_username",
         )
+
+
+class DashboardStandalonePersonalInfoSerializer(serializers.ModelSerializer[PersonalInfo]):
+    """
+    Used in the Tooljet dashboard to identify a coordinator by their email.
+    Returns minimal data.
+    """
+
+    class Meta:
+        model = PersonalInfo
+        fields = (
+            "id",
+            "email",
+        )
+        read_only_fields = fields

--- a/api/serializers/personal_info.py
+++ b/api/serializers/personal_info.py
@@ -71,7 +71,7 @@ class DashboardPersonalInfoSerializer(serializers.ModelSerializer[PersonalInfo])
         )
 
 
-class DashboardStandalonePersonalInfoSerializer(serializers.ModelSerializer[PersonalInfo]):
+class DashboardMinifiedPersonalInfoSerializer(serializers.ModelSerializer[PersonalInfo]):
     """
     Used in the Tooljet dashboard to identify a coordinator by their email.
     Returns minimal data.

--- a/api/urls.py
+++ b/api/urls.py
@@ -19,6 +19,7 @@ from api.views import (
     TeacherUnder18ViewSet,
     TeacherViewSet,
 )
+from api.views.personal_info import DashboardPersonalInfoViewSet
 
 internal_router = DefaultRouter()
 internal_router.register(r"groups", GroupViewSet, basename="groups")
@@ -54,6 +55,11 @@ dashboard_router.register(
     r"teachers_with_personal_info",
     DashboardTeacherWithPersonalInfoViewSet,
     basename="teachers_with_personal_info",
+)
+dashboard_router.register(
+    "personal_info",
+    DashboardPersonalInfoViewSet,
+    basename="personal_info",
 )
 
 # "Internal" API is used by bot and "dashboard" API is used by the Tooljet

--- a/api/views/personal_info.py
+++ b/api/views/personal_info.py
@@ -15,7 +15,7 @@ from api.serializers import (
     PersonalInfoSerializer,
 )
 from api.serializers.errors import BaseAPIExceptionSerializer, ValidationErrorSerializer
-from api.serializers.personal_info import DashboardStandalonePersonalInfoSerializer
+from api.serializers.personal_info import DashboardMinifiedPersonalInfoSerializer
 
 
 class PersonalInfoViewSet(viewsets.ModelViewSet[PersonalInfo]):
@@ -90,4 +90,4 @@ class DashboardPersonalInfoViewSet(viewsets.ReadOnlyModelViewSet[PersonalInfo]):
     queryset = PersonalInfo.objects.all()
     filter_backends = (filters.DjangoFilterBackend,)
     filterset_class = DashboardPersonalInfoFilter
-    serializer_class = DashboardStandalonePersonalInfoSerializer
+    serializer_class = DashboardMinifiedPersonalInfoSerializer

--- a/api/views/personal_info.py
+++ b/api/views/personal_info.py
@@ -7,6 +7,7 @@ from rest_framework.response import Response
 from rest_framework.serializers import BaseSerializer
 
 from api.filters import PersonalInfoFilter
+from api.filters.personal_info import DashboardPersonalInfoFilter
 from api.models import PersonalInfo
 from api.serializers import (
     CheckChatIdExistenceSerializer,
@@ -14,6 +15,7 @@ from api.serializers import (
     PersonalInfoSerializer,
 )
 from api.serializers.errors import BaseAPIExceptionSerializer, ValidationErrorSerializer
+from api.serializers.personal_info import DashboardStandalonePersonalInfoSerializer
 
 
 class PersonalInfoViewSet(viewsets.ModelViewSet[PersonalInfo]):
@@ -56,7 +58,6 @@ class PersonalInfoViewSet(viewsets.ModelViewSet[PersonalInfo]):
     @extend_schema(
         parameters=[
             OpenApiParameter(name="registration_telegram_bot_chat_id", type=int, required=True),
-            OpenApiParameter(name="email", type=str, required=False),
         ],
         responses={
             status.HTTP_200_OK: OpenApiResponse(
@@ -83,3 +84,10 @@ class PersonalInfoViewSet(viewsets.ModelViewSet[PersonalInfo]):
         serializer = self.get_serializer(data=request.query_params)
         serializer.is_valid(raise_exception=True)
         return Response(request.query_params)
+
+
+class DashboardPersonalInfoViewSet(viewsets.ReadOnlyModelViewSet[PersonalInfo]):
+    queryset = PersonalInfo.objects.all()
+    filter_backends = (filters.DjangoFilterBackend,)
+    filterset_class = DashboardPersonalInfoFilter
+    serializer_class = DashboardStandalonePersonalInfoSerializer

--- a/api/views/personal_info.py
+++ b/api/views/personal_info.py
@@ -56,6 +56,7 @@ class PersonalInfoViewSet(viewsets.ModelViewSet[PersonalInfo]):
     @extend_schema(
         parameters=[
             OpenApiParameter(name="registration_telegram_bot_chat_id", type=int, required=True),
+            OpenApiParameter(name="email", type=str, required=False),
         ],
         responses={
             status.HTTP_200_OK: OpenApiResponse(

--- a/tests/fixtures/personal_info.py
+++ b/tests/fixtures/personal_info.py
@@ -21,3 +21,25 @@ def fake_personal_info_data(faker):
         ),
         "chatwoot_conversation_id": faker.pyint(),
     }
+
+
+@pytest.fixture
+def fake_personal_info_list(faker):
+    return [
+        {
+            "communication_language_mode": faker.random_element(CommunicationLanguageMode.values),
+            "first_name": faker.first_name(),
+            "last_name": faker.last_name(),
+            "telegram_username": faker.user_name(),
+            "email": faker.email(),
+            "phone": faker.numerify("+3531#######"),
+            "utc_timedelta": "03:00:00",
+            "information_source": faker.text(),
+            "registration_telegram_bot_chat_id": faker.pyint(),
+            "registration_telegram_bot_language": faker.random_element(
+                RegistrationTelegramBotLanguage.values
+            ),
+            "chatwoot_conversation_id": faker.pyint(),
+        }
+        for _ in range(10)
+    ]

--- a/tests/tests_api/test_personal_info.py
+++ b/tests/tests_api/test_personal_info.py
@@ -48,24 +48,36 @@ def test_personal_info_get_with_params_returns_200_and_data_with_existing_chat_i
         assert response.json()[0][param] == fake_personal_info_data[param]
 
 
-def test_personal_info_get_applies_email_filter(
+def test_dashboard_personal_info_get_applies_email_filter(
     api_client, fake_personal_info_data, fake_personal_info_list
 ):
     for item in fake_personal_info_list:
         api_client.post("/api/personal_info/", data=item)
 
-    api_client.post("/api/personal_info/", data=fake_personal_info_data)
+    expected_id = api_client.post("/api/personal_info/", data=fake_personal_info_data).json()["id"]
     expected_email = fake_personal_info_data["email"]
 
     response = api_client.get(
-        path=f"/api/personal_info/?email={expected_email}",
+        path=f"/api/dashboard/personal_info/?email={expected_email}",
     )
     assert response.status_code == status.HTTP_200_OK
     assert len(response.json()) == 1
     # checking some basic attrs (cannot compare two objects directly
     # because some fields were added during creation)
-    for param in ["first_name", "last_name", "email", "information_source"]:
-        assert response.json()[0][param] == fake_personal_info_data[param]
+    result = response.json()[0]
+    assert result["id"] == expected_id
+    assert result["email"] == expected_email
+
+
+def test_dashboard_personal_info_get_handles_unknown_email(api_client, fake_personal_info_list):
+    for item in fake_personal_info_list:
+        api_client.post("/api/personal_info/", data=item)
+
+    response = api_client.get(
+        path="/api/dashboard/personal_info/?email=unknownEmail@samanthasgroup.com",
+    )
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == []
 
 
 def test_personal_info_get_with_params_returns_200_and_empty_list_with_unknown_chat_id(

--- a/tests/tests_api/test_personal_info.py
+++ b/tests/tests_api/test_personal_info.py
@@ -58,7 +58,10 @@ def test_dashboard_personal_info_get_applies_email_filter(
     expected_email = fake_personal_info_data["email"]
 
     response = api_client.get(
-        path=f"/api/dashboard/personal_info/?email={expected_email}",
+        path="/api/dashboard/personal_info/",
+        data={
+            "email": expected_email,
+        },
     )
     assert response.status_code == status.HTTP_200_OK
     assert len(response.json()) == 1
@@ -72,7 +75,10 @@ def test_dashboard_personal_info_get_handles_unknown_email(api_client, fake_pers
         api_client.post("/api/personal_info/", data=item)
 
     response = api_client.get(
-        path="/api/dashboard/personal_info/?email=unknownEmail@samanthasgroup.com",
+        path="/api/dashboard/personal_info/",
+        data={
+            "email": "unknownEmail@samanthasgroup.com",
+        },
     )
     assert response.status_code == status.HTTP_200_OK
     assert response.json() == []

--- a/tests/tests_api/test_personal_info.py
+++ b/tests/tests_api/test_personal_info.py
@@ -48,7 +48,7 @@ def test_personal_info_get_with_params_returns_200_and_data_with_existing_chat_i
         assert response.json()[0][param] == fake_personal_info_data[param]
 
 
-def test_personal_info_get_with_params_returns_200_and_data_with_existing_email(
+def test_personal_info_get_applies_email_filter(
     api_client, fake_personal_info_data, fake_personal_info_list
 ):
     for item in fake_personal_info_list:

--- a/tests/tests_api/test_personal_info.py
+++ b/tests/tests_api/test_personal_info.py
@@ -62,8 +62,6 @@ def test_dashboard_personal_info_get_applies_email_filter(
     )
     assert response.status_code == status.HTTP_200_OK
     assert len(response.json()) == 1
-    # checking some basic attrs (cannot compare two objects directly
-    # because some fields were added during creation)
     result = response.json()[0]
     assert result["id"] == expected_id
     assert result["email"] == expected_email

--- a/tests/tests_api/test_personal_info.py
+++ b/tests/tests_api/test_personal_info.py
@@ -29,20 +29,39 @@ def test_personal_info_create(api_client, fake_personal_info_data):
 
 
 def test_personal_info_get_with_params_returns_200_and_data_with_existing_chat_id(
-    api_client, fake_personal_info_data
+    api_client, fake_personal_info_data, fake_personal_info_list
 ):
+    for item in fake_personal_info_list:
+        api_client.post("/api/personal_info/", data=item)
+
     api_client.post("/api/personal_info/", data=fake_personal_info_data)
+    expected_chat_id = fake_personal_info_data["registration_telegram_bot_chat_id"]
 
     response = api_client.get(
-        path="/api/personal_info/",
-        params={
-            "registration_telegram_bot_chat_id": fake_personal_info_data[
-                "registration_telegram_bot_chat_id"
-            ]
-        },
+        path=f"/api/personal_info/?registration_telegram_bot_chat_id={expected_chat_id}",
     )
     assert response.status_code == status.HTTP_200_OK
+    assert len(response.json()) == 1
+    # checking some basic attrs (cannot compare two objects directly
+    # because some fields were added during creation)
+    for param in ["first_name", "last_name", "email", "information_source"]:
+        assert response.json()[0][param] == fake_personal_info_data[param]
 
+
+def test_personal_info_get_with_params_returns_200_and_data_with_existing_email(
+    api_client, fake_personal_info_data, fake_personal_info_list
+):
+    for item in fake_personal_info_list:
+        api_client.post("/api/personal_info/", data=item)
+
+    api_client.post("/api/personal_info/", data=fake_personal_info_data)
+    expected_email = fake_personal_info_data["email"]
+
+    response = api_client.get(
+        path=f"/api/personal_info/?email={expected_email}",
+    )
+    assert response.status_code == status.HTTP_200_OK
+    assert len(response.json()) == 1
     # checking some basic attrs (cannot compare two objects directly
     # because some fields were added during creation)
     for param in ["first_name", "last_name", "email", "information_source"]:


### PR DESCRIPTION
~~Tiny PR to enable filtering of the personal info list by email - to be used in the Tooljet dashboard~~
This PR adds a dashboard viewset to retrieve personal info details - to be used to "authenticate" a coordinator upon first opening the dashboard app
<img width="1679" alt="image" src="https://github.com/samanthasgroup/django-webapps/assets/79531889/e13a7be9-be55-4510-b8e6-802199d601bf">
