### PR TITLE
Bug fix: coordinator email filter not being applied in the student with personal info view

### DIFF
--- a/api/views/student.py
+++ b/api/views/student.py
@@ -1,3 +1,4 @@
+from django_filters import rest_framework as filters
 from drf_spectacular.utils import OpenApiResponse, extend_schema
 from rest_framework import status, viewsets
 from rest_framework.decorators import action
@@ -71,8 +72,8 @@ class DashboardStudentWithPersonalInfoViewSet(viewsets.ReadOnlyModelViewSet[Stud
     """
 
     # TODO permissions?
-    # TODO test this API
     lookup_field = "personal_info_id"
     queryset = Student.objects.all()
     serializer_class = DashboardStudentWithPersonalInfoSerializer
+    filter_backends = (filters.DjangoFilterBackend,)
     filterset_class = StudentFilter


### PR DESCRIPTION
Just a quick PR, noticed this while testing out the tooljet interface

![image](https://github.com/samanthasgroup/django-webapps/assets/79531889/df937bf5-e887-49ee-9ebd-74bf8847d3b0)
