### PR TITLE
Adjust teacher status expectations after group creation or confirmation

### DIFF
--- a/tests/tests_api/test_group.py
+++ b/tests/tests_api/test_group.py
@@ -436,7 +436,7 @@ class TestGroupCreation:
             assert_date_time_with_timestamp(log_event.date_time, timestamp)
 
         for teacher in group.teachers.iterator():
-            assert teacher.project_status == TeacherProjectStatus.NO_GROUP_YET
+            assert teacher.project_status == TeacherProjectStatus.WORKING
             assert teacher.status_since == common_status_since
             log_event: TeacherLogEvent = TeacherLogEvent.objects.get(teacher_id=teacher.pk)
             assert log_event.to_group.id == created_group.id
@@ -476,7 +476,7 @@ class TestDashboardGroupConfirmReadyToStart:
             assert_date_time_with_timestamp(log_event.date_time, timestamp)
 
         for teacher in group.teachers.iterator():
-            assert teacher.project_status == TeacherProjectStatus.NO_GROUP_YET
+            assert teacher.project_status == TeacherProjectStatus.WORKING
             assert teacher.status_since == common_status_since
 
             log_event: TeacherLogEvent = TeacherLogEvent.objects.get(teacher_id=teacher.pk)


### PR DESCRIPTION
## Summary
- Expect teachers to be WORKING after a group is created or confirmed

## Testing
- `pre-commit run --files tests/tests_api/test_group.py`
- `DJANGO_SETTINGS_MODULE=django_webapps.settings pytest tests/tests_api/test_group.py` *(fails: django.db.utils.OperationalError, missing DB tables)*

------
https://chatgpt.com/codex/tasks/task_e_68b0334334a0832c97cf72bf6f2ddc9d